### PR TITLE
fix: Improve `Collection::filter` method to not retain indices.

### DIFF
--- a/src/Domain/Collection.php
+++ b/src/Domain/Collection.php
@@ -4,18 +4,13 @@ declare(strict_types=1);
 
 namespace GeekCell\Ddd\Domain;
 
-use ArrayAccess;
-use ArrayIterator;
 use Assert;
-use Countable;
-use IteratorAggregate;
-use Traversable;
 
-class Collection implements ArrayAccess, Countable, IteratorAggregate
+class Collection implements \ArrayAccess, \Countable, \IteratorAggregate
 {
     /**
      * @template T of object
-     * @extends IteratorAggregate<T>
+     * @extends \IteratorAggregate<T>
      *
      * @param T[] $items
      * @param class-string<T> $itemType
@@ -63,7 +58,7 @@ class Collection implements ArrayAccess, Countable, IteratorAggregate
     public function filter(callable $callback): static
     {
         return new static(
-            array_filter($this->items, $callback),
+            \array_values(\array_filter($this->items, $callback)),
             $this->itemType,
         );
     }
@@ -81,15 +76,15 @@ class Collection implements ArrayAccess, Countable, IteratorAggregate
      */
     public function map(callable $callback, bool $inferTypes = true): static
     {
-        $mapResult = array_map($callback, $this->items);
-        $firstItem = reset($mapResult);
+        $mapResult = \array_map($callback, $this->items);
+        $firstItem = \reset($mapResult);
 
         if ($firstItem === false || !is_object($firstItem)) {
             return new static($mapResult);
         }
 
         if ($inferTypes && $this->itemType !== null) {
-            return new static($mapResult, get_class($firstItem));
+            return new static($mapResult, \get_class($firstItem));
         }
 
         return new static($mapResult);
@@ -105,7 +100,7 @@ class Collection implements ArrayAccess, Countable, IteratorAggregate
      */
     public function reduce(callable $callback, mixed $initial = null): mixed
     {
-        return array_reduce($this->items, $callback, $initial);
+        return \array_reduce($this->items, $callback, $initial);
     }
 
     /**
@@ -113,7 +108,7 @@ class Collection implements ArrayAccess, Countable, IteratorAggregate
      */
     public function offsetExists(mixed $offset): bool
     {
-        if (!is_int($offset)) {
+        if (!\is_int($offset)) {
             return false;
         }
 
@@ -159,14 +154,14 @@ class Collection implements ArrayAccess, Countable, IteratorAggregate
      */
     public function count(): int
     {
-        return count($this->items);
+        return \count($this->items);
     }
 
     /**
      * @inheritDoc
      */
-    public function getIterator(): Traversable
+    public function getIterator(): \Traversable
     {
-        return new ArrayIterator($this->items);
+        return new \ArrayIterator($this->items);
     }
 }

--- a/tests/Domain/CollectionTest.php
+++ b/tests/Domain/CollectionTest.php
@@ -166,6 +166,21 @@ class CollectionTest extends TestCase
         $this->assertNotSame($collection, $newCollection);
     }
 
+    public function testFilterWithAdjustedIndices(): void
+    {
+        // Given
+        $items = [1, 2, 3, 4];
+        $collection = new Collection($items);
+
+        // When
+        $newCollection = $collection->filter(fn (int $i) => $i % 2 === 0);
+
+        // Then
+        $this->assertCount(2, $newCollection);
+        $this->assertEquals(2, $newCollection[0]);
+        $this->assertEquals(4, $newCollection[1]);
+    }
+
     public function testMap(): void
     {
         // Given


### PR DESCRIPTION
Wrapping `\array_filter` with `\array_values` forces a reindex.

refs: #12