### PR TITLE
refac: let ValueObject extend from Stringable interface

### DIFF
--- a/src/Contracts/Domain/ValueObject.php
+++ b/src/Contracts/Domain/ValueObject.php
@@ -4,7 +4,9 @@ declare(strict_types=1);
 
 namespace GeekCell\Ddd\Contracts\Domain;
 
-interface ValueObject
+use Stringable;
+
+interface ValueObject extends Stringable
 {
     /**
      * Check if the given object is equal to the current object.
@@ -20,11 +22,4 @@ interface ValueObject
      * @return mixed
      */
     public function getValue(): mixed;
-
-    /**
-     * Return the string representation of the value object.
-     *
-     * @return string
-     */
-    public function __toString(): string;
 }


### PR DESCRIPTION
PHP 8.0 introduced the [Stringable](https://www.php.net/manual/en/class.stringable.php) interface. This enables users of an object that implements it to write `(string)$foo` instead of `$foo->__toString()`. Additionally Stringable is currently supported by static code analysis tools like PHPStan which will help users of this library to write simpler/less code.