### PR TITLE
feat: add generic/template support for queries/commands

### DIFF
--- a/src/Contracts/Application/Command.php
+++ b/src/Contracts/Application/Command.php
@@ -4,6 +4,9 @@ declare(strict_types=1);
 
 namespace GeekCell\Ddd\Contracts\Application;
 
+/**
+ * @template T of mixed
+ */
 interface Command
 {
 }

--- a/src/Contracts/Application/CommandBus.php
+++ b/src/Contracts/Application/CommandBus.php
@@ -9,8 +9,9 @@ interface CommandBus
     /**
      * Dispatch a command to the appropriate handler.
      *
-     * @param Command $command
-     * @return mixed
+     * @template T of mixed
+     * @param Command<T> $command
+     * @return T
      */
     public function dispatch(Command $command): mixed;
 }

--- a/src/Contracts/Application/Query.php
+++ b/src/Contracts/Application/Query.php
@@ -4,6 +4,9 @@ declare(strict_types=1);
 
 namespace GeekCell\Ddd\Contracts\Application;
 
+/**
+ * @template T of mixed
+ */
 interface Query
 {
 }

--- a/src/Contracts/Application/QueryBus.php
+++ b/src/Contracts/Application/QueryBus.php
@@ -9,8 +9,9 @@ interface QueryBus
     /**
      * Dispatch a query to the appropriate handler.
      *
-     * @param Query $query
-     * @return mixed
+     * @template T of mixed
+     * @param Query<T> $query
+     * @return T
      */
     public function dispatch(Query $query): mixed;
 }


### PR DESCRIPTION
This PR adds support for specifying the "result type" of a query/command.

This is useful for type detection inside PHPStorm/PHPStan.

Example usage of the query in which types would be properly detected:
```php
use GeekCell\Ddd\Contracts\Application\Query;
use GeekCell\Ddd\Contracts\Application\QueryHandler;
use GeekCell\Ddd\Infrastructure\InMemory\QueryBus;

class Foo {}

/**
 * @implements Query<Foo>
 */
class FooQuery implements Query {}

class FooQueryHandler implements QueryHandler {}

$queryHandler = new FooQueryHandler();
$queryBus = new QueryBus();
$queryBus->registerHandler($queryHandler);

$result = $queryBus->dispatch(new FooQuery());
```

In the above example static analysis would tell us that `$result` is of type `Foo` since the Query had the `@implements` annotation. If no `@implements` documentation is given that return is still `mixed` like it used to so no breaking change is introduced as far as I can tell.