### PR TITLE
Improve type definitions

### DIFF
--- a/src/Contracts/Domain/Paginator.php
+++ b/src/Contracts/Domain/Paginator.php
@@ -4,10 +4,11 @@ declare(strict_types=1);
 
 namespace GeekCell\Ddd\Contracts\Domain;
 
-use Countable;
-use IteratorAggregate;
-
-interface Paginator extends Countable, IteratorAggregate
+/**
+ * @template T of object
+ * @extends \IteratorAggregate<T>
+ */
+interface Paginator extends \Countable, \IteratorAggregate
 {
     /**
      * Returns the current page.

--- a/src/Contracts/Domain/Repository.php
+++ b/src/Contracts/Domain/Repository.php
@@ -4,16 +4,18 @@ declare(strict_types=1);
 
 namespace GeekCell\Ddd\Contracts\Domain;
 
-use Countable;
 use GeekCell\Ddd\Domain\Collection;
-use IteratorAggregate;
 
-interface Repository extends Countable, IteratorAggregate
+/**
+ * @template T of object
+ * @extends \IteratorAggregate<T>
+ */
+interface Repository extends \Countable, \IteratorAggregate
 {
     /**
      * Returns a collection of items.
      *
-     * @return Collection
+     * @return Collection<T>
      */
     public function collect(): Collection;
 
@@ -23,7 +25,7 @@ interface Repository extends Countable, IteratorAggregate
      * @param int $itemsPerPage
      * @param int $currentPage
      *
-     * @return Paginator
+     * @return Paginator<T>
      */
     public function paginate(
         int $itemsPerPage,

--- a/src/Domain/Collection.php
+++ b/src/Domain/Collection.php
@@ -6,14 +6,15 @@ namespace GeekCell\Ddd\Domain;
 
 use Assert;
 
+/**
+ * @template T of object
+ * @extends \IteratorAggregate<T>
+ */
 class Collection implements \ArrayAccess, \Countable, \IteratorAggregate
 {
     /**
-     * @template T of object
-     * @extends \IteratorAggregate<T>
-     *
      * @param T[] $items
-     * @param class-string<T> $itemType
+     * @param class-string<T>|null $itemType
      *
      * @throws Assert\AssertionFailedException
      */

--- a/src/Domain/ValueObject/Id.php
+++ b/src/Domain/ValueObject/Id.php
@@ -29,7 +29,7 @@ abstract class Id extends ValueObject
     /**
      * @inheritDoc
      */
-    public function getValue(): mixed
+    public function getValue(): int
     {
         return $this->id;
     }

--- a/src/Domain/ValueObject/Uuid.php
+++ b/src/Domain/ValueObject/Uuid.php
@@ -55,7 +55,7 @@ class Uuid extends ValueObject
     /**
      * @inheritDoc
      */
-    public function getValue(): mixed
+    public function getValue(): string
     {
         return $this->uuid;
     }

--- a/src/Infrastructure/InMemory/Paginator.php
+++ b/src/Infrastructure/InMemory/Paginator.php
@@ -11,8 +11,17 @@ use GeekCell\Ddd\Domain\Collection;
 use LimitIterator;
 use Traversable;
 
+/**
+ * @template T of object
+ * @extends PaginatorInterface<T>
+ */
 class Paginator implements PaginatorInterface, ArrayAccess
 {
+    /**
+     * @param Collection<T> $collection
+     * @param int $itemsPerPage
+     * @param int $currentPage
+     */
     public function __construct(
         private readonly Collection $collection,
         private int $itemsPerPage,

--- a/src/Infrastructure/InMemory/Repository.php
+++ b/src/Infrastructure/InMemory/Repository.php
@@ -11,6 +11,10 @@ use GeekCell\Ddd\Domain\Collection;
 use GeekCell\Ddd\Infrastructure\InMemory\Paginator as InMemoryPaginator;
 use Traversable;
 
+/**
+ * @template T of object
+ * @extends RepositoryInterface<T>
+ */
 abstract class Repository implements RepositoryInterface
 {
     /**
@@ -19,9 +23,6 @@ abstract class Repository implements RepositoryInterface
     protected array $items = [];
 
     /**
-     * @template T of object
-     * @extends IteratorAggregate<T>
-     *
      * @param class-string<T> $itemType
      */
     public function __construct(


### PR DESCRIPTION
The types of the id can be narrowed down a bit for the `getValue` call.

(Proper) support for generics on the Collection, Repository and Paginator have been added as well.