### PR TITLE
Enable InMemory repository to accept items in constructor

### DIFF
--- a/src/Contracts/Domain/Paginator.php
+++ b/src/Contracts/Domain/Paginator.php
@@ -4,10 +4,11 @@ declare(strict_types=1);
 
 namespace GeekCell\Ddd\Contracts\Domain;
 
-use Countable;
-use IteratorAggregate;
-
-interface Paginator extends Countable, IteratorAggregate
+/**
+ * @template T of object
+ * @extends \IteratorAggregate<T>
+ */
+interface Paginator extends \Countable, \IteratorAggregate
 {
     /**
      * Returns the current page.

--- a/src/Contracts/Domain/Repository.php
+++ b/src/Contracts/Domain/Repository.php
@@ -4,16 +4,18 @@ declare(strict_types=1);
 
 namespace GeekCell\Ddd\Contracts\Domain;
 
-use Countable;
 use GeekCell\Ddd\Domain\Collection;
-use IteratorAggregate;
 
-interface Repository extends Countable, IteratorAggregate
+/**
+ * @template T of object
+ * @extends \IteratorAggregate<T>
+ */
+interface Repository extends \Countable, \IteratorAggregate
 {
     /**
      * Returns a collection of items.
      *
-     * @return Collection
+     * @return Collection<T>
      */
     public function collect(): Collection;
 
@@ -23,7 +25,7 @@ interface Repository extends Countable, IteratorAggregate
      * @param int $itemsPerPage
      * @param int $currentPage
      *
-     * @return Paginator
+     * @return Paginator<T>
      */
     public function paginate(
         int $itemsPerPage,

--- a/src/Domain/Collection.php
+++ b/src/Domain/Collection.php
@@ -6,14 +6,15 @@ namespace GeekCell\Ddd\Domain;
 
 use Assert;
 
+/**
+ * @template T of object
+ * @extends \IteratorAggregate<T>
+ */
 class Collection implements \ArrayAccess, \Countable, \IteratorAggregate
 {
     /**
-     * @template T of object
-     * @extends \IteratorAggregate<T>
-     *
      * @param T[] $items
-     * @param class-string<T> $itemType
+     * @param class-string<T>|null $itemType
      *
      * @throws Assert\AssertionFailedException
      */

--- a/src/Domain/ValueObject/Id.php
+++ b/src/Domain/ValueObject/Id.php
@@ -29,7 +29,7 @@ abstract class Id extends ValueObject
     /**
      * @inheritDoc
      */
-    public function getValue(): mixed
+    public function getValue(): int
     {
         return $this->id;
     }

--- a/src/Domain/ValueObject/Uuid.php
+++ b/src/Domain/ValueObject/Uuid.php
@@ -55,7 +55,7 @@ class Uuid extends ValueObject
     /**
      * @inheritDoc
      */
-    public function getValue(): mixed
+    public function getValue(): string
     {
         return $this->uuid;
     }

--- a/src/Infrastructure/InMemory/Paginator.php
+++ b/src/Infrastructure/InMemory/Paginator.php
@@ -11,8 +11,17 @@ use GeekCell\Ddd\Domain\Collection;
 use LimitIterator;
 use Traversable;
 
+/**
+ * @template T of object
+ * @extends PaginatorInterface<T>
+ */
 class Paginator implements PaginatorInterface, ArrayAccess
 {
+    /**
+     * @param Collection<T> $collection
+     * @param int $itemsPerPage
+     * @param int $currentPage
+     */
     public function __construct(
         private readonly Collection $collection,
         private int $itemsPerPage,

--- a/src/Infrastructure/InMemory/Repository.php
+++ b/src/Infrastructure/InMemory/Repository.php
@@ -18,17 +18,15 @@ use Traversable;
 abstract class Repository implements RepositoryInterface
 {
     /**
-     * @var T[]
-     */
-    protected array $items = [];
-
-    /**
      * @param class-string<T> $itemType
+     * @param T[] $items
      */
     public function __construct(
         private string $itemType,
+        protected array $items = []
     ) {
         Assert::that($this->itemType)->classExists();
+        Assert::thatAll($this->items)->isInstanceOf($this->itemType);
     }
 
     /**

--- a/src/Infrastructure/InMemory/Repository.php
+++ b/src/Infrastructure/InMemory/Repository.php
@@ -11,6 +11,10 @@ use GeekCell\Ddd\Domain\Collection;
 use GeekCell\Ddd\Infrastructure\InMemory\Paginator as InMemoryPaginator;
 use Traversable;
 
+/**
+ * @template T of object
+ * @extends RepositoryInterface<T>
+ */
 abstract class Repository implements RepositoryInterface
 {
     /**
@@ -19,9 +23,6 @@ abstract class Repository implements RepositoryInterface
     protected array $items = [];
 
     /**
-     * @template T of object
-     * @extends IteratorAggregate<T>
-     *
      * @param class-string<T> $itemType
      */
     public function __construct(


### PR DESCRIPTION
Currently the InMemoryRepository has no way to accept any items making it basically a "NullRepository". This PR adds the `items` parameeter to the constructor (as a promoted property) to help mitigate this.

**NOTE: This should be merged after [https://github.com/geekcell/php-ddd/pull/18](https://github.com/geekcell/php-ddd/pull/18)**

Previously a class that extends the Repository would write something like this:
```php
class FooRepository extends Repository {
    public function __construct() {
        parent::__construct(Foo::class);
        $this->items = [new Foo()];
    }
}
```

If this PR gets merged a user could use a more straight forward interface:
```php
class FooRepository extends Repository {
    public function __construct() {
        parent::__construct(Foo::class, [new Foo()]);
    }
}
```

In addition this enables users of the InMemoryRepository to implement the "filter" option a bit more straight forward.

Instead of this
```php
public function findByEmail(string $email): self
{
    $filtered = [];
    foreach ($this->items as $item) {
        if ($item->email === $email) {
            filtered[] = $item;
        }
    }

    $self = new self($this->itemType);
    $self->items = $filtered;

     return $self;
}
```

A user can now do this:
```php
public function findByEmail(string $email): self
{
    $filtered = [];
    foreach ($this->items as $item) {
        if ($item->email === $email) {
            filtered[] = $item;
        }
    }

    return new self($this->itemType, $filtered);
}
```