### PR TITLE
Fix: PHPDoc generic for InMemoryRepository

### DIFF
--- a/src/Infrastructure/InMemory/Repository.php
+++ b/src/Infrastructure/InMemory/Repository.php
@@ -13,7 +13,7 @@ use Traversable;
 
 /**
  * @template T of object
- * @extends RepositoryInterface<T>
+ * @implements RepositoryInterface<T>
  */
 abstract class Repository implements RepositoryInterface
 {


### PR DESCRIPTION
The phpdoc annotation to describe generics for the InMemoryRepository is not valid.

It claims to "extend" an interface while it should be "implementing" it