### PR TITLE
Add functions to Collection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,13 +8,15 @@ Added a couple of functions to the [Collection](./src/Domain/Collection.php) cla
 
 The following functions were added:
 * `fromIterable` - enables users of the collection to construction the collection from an iterable value like iterators, generators, etc.
-* `every` - Function that returns true if given callback returns truthy values for all items
-* `none` - Function that returns true if given callback returns falsy values for all items
-* `some` - Function that returns true if given callback returns truthy values on some items
+* `every` - Returns true if given callback returns truthy values for all items
+* `none` - Returns true if given callback returns falsy values for all items
+* `some` - Returns true if given callback returns truthy values on some items
 * `first` - Get the first element of the collection that matches a callback, if given. Throws exception if collection is empty or predicate is never satisfied
 * `firstOr` - Same as first but returns $fallbackValue if collection is empty or predicate is never satisfied
 * `last` - Get the last element of the collection that matches a callback, if given. Throws exception if collection is empty or predicate is never satisfied
 * `lastOr` - Same as last but returns $fallbackValue if collection is empty or predicate is never satisfied
+* `isEmpty` - Returns whether the collection is empty
+* `hasItems` - Returns whether the collection has items
 
 ## [1.4.0](https://github.com/geekcell/php-ddd/compare/v1.3.1...v1.4.0) (2023-12-19)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## [1.4.1](https://github.com/geekcell/php-ddd/compare/v1.4.0...v1.4.1) (2024-01-05)
+## [1.5.0](https://github.com/geekcell/php-ddd/compare/v1.4.0...v1.5.0) (2024-01-05)
 
 ### Features
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,21 @@
 # Changelog
 
+## [1.4.1](https://github.com/geekcell/php-ddd/compare/v1.4.0...v1.4.1) (2024-01-05)
+
+### Features
+
+Added a couple of functions to the [Collection](./src/Domain/Collection.php) class to enable a smoother developer experience when trying use it in a more functional style
+
+The following functions were added:
+* `fromIterable` - enables users of the collection to construction the collection from an iterable value like iterators, generators, etc.
+* `every` - Function that returns true if given callback returns truthy values for all items
+* `none` - Function that returns true if given callback returns falsy values for all items
+* `some` - Function that returns true if given callback returns truthy values on some items
+* `first` - Get the first element of the collection that matches a callback, if given. Throws exception if collection is empty or predicate is never satisfied
+* `firstOr` - Same as first but returns $fallbackValue if collection is empty or predicate is never satisfied
+* `last` - Get the last element of the collection that matches a callback, if given. Throws exception if collection is empty or predicate is never satisfied
+* `lastOr` - Same as last but returns $fallbackValue if collection is empty or predicate is never satisfied
+
 ## [1.4.0](https://github.com/geekcell/php-ddd/compare/v1.3.1...v1.4.0) (2023-12-19)
 
 

--- a/src/Domain/Collection.php
+++ b/src/Domain/Collection.php
@@ -35,6 +35,7 @@ class Collection implements \ArrayAccess, \Countable, \IteratorAggregate
      * @param iterable<T> $items
      * @param class-string<T>|null $itemType
      * @return self<T>
+     * @throws Assert\AssertionFailedException
      */
     public static function fromIterable(iterable $items, ?string $itemType = null): static
     {
@@ -47,6 +48,75 @@ class Collection implements \ArrayAccess, \Countable, \IteratorAggregate
         }
 
         return new static(iterator_to_array($items), $itemType);
+    }
+
+    /**
+     * Returns true if every value in the collection passes the callback truthy test. Opposite of self::none().
+     * Callback arguments will be element, index, collection.
+     * Function short-circuits on first falsy return value
+     *
+     * @param ?callable(T, int, static): bool $callback
+     * @return bool
+     */
+    public function every(callable $callback = null): bool
+    {
+        if ($callback === null) {
+            $callback = static fn ($item, $index, $self) => $item;
+        }
+
+        foreach ($this->items as $index => $item) {
+            if (!$callback($item, $index, $this)) {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    /**
+     * Returns true if every value in the collection passes the callback falsy test. Opposite of self::every().
+     * Callback arguments will be element, index, collection.
+     * Function short-circuits on first truthy return value
+     *
+     * @param ?callable(T, int, static): bool $callback
+     * @return bool
+     */
+    public function none(callable $callback = null): bool
+    {
+        if ($callback === null) {
+            $callback = static fn ($item, $index, $self) => $item;
+        }
+
+        foreach ($this->items as $index => $item) {
+            if ($callback($item, $index, $this)) {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    /**
+     * Returns true if at least one value in the collection passes the callback truthy test.
+     * Callback arguments will be element, index, collection.
+     * Function short-circuits on first truthy return value
+     *
+     * @param ?callable(T, int, static): bool $callback
+     * @return bool
+     */
+    public function some(callable $callback = null): bool
+    {
+        if ($callback === null) {
+            $callback = static fn ($item, $index, $self) => $item;
+        }
+
+        foreach ($this->items as $index => $item) {
+            if ($callback($item, $index, $this)) {
+                return true;
+            }
+        }
+
+        return false;
     }
 
     /**

--- a/src/Domain/Collection.php
+++ b/src/Domain/Collection.php
@@ -232,6 +232,22 @@ class Collection implements ArrayAccess, Countable, IteratorAggregate
     }
 
     /**
+     * Returns whether the collection is empty (has no items)
+     */
+    public function isEmpty(): bool
+    {
+        return $this->items === [];
+    }
+
+    /**
+     * Returns whether the collection has items
+     */
+    public function hasItems(): bool
+    {
+        return $this->items !== [];
+    }
+
+    /**
      * Add one or more items to the collection. It **does not** modify the
      * current collection, but returns a new one.
      *

--- a/src/Domain/Collection.php
+++ b/src/Domain/Collection.php
@@ -30,7 +30,7 @@ class Collection implements \ArrayAccess, \Countable, \IteratorAggregate
 
     /**
      * Creates a collection from a given iterable of items.
-     * This function is useful when trying to create a collection from a generator or an iterator
+     * This function is useful when trying to create a collection from a generator or an iterator.
      *
      * @param iterable<T> $items
      * @param class-string<T>|null $itemType
@@ -53,7 +53,7 @@ class Collection implements \ArrayAccess, \Countable, \IteratorAggregate
     /**
      * Returns true if every value in the collection passes the callback truthy test. Opposite of self::none().
      * Callback arguments will be element, index, collection.
-     * Function short-circuits on first falsy return value
+     * Function short-circuits on first falsy return value.
      *
      * @param ?callable(T, int, static): bool $callback
      * @return bool
@@ -76,7 +76,7 @@ class Collection implements \ArrayAccess, \Countable, \IteratorAggregate
     /**
      * Returns true if every value in the collection passes the callback falsy test. Opposite of self::every().
      * Callback arguments will be element, index, collection.
-     * Function short-circuits on first truthy return value
+     * Function short-circuits on first truthy return value.
      *
      * @param ?callable(T, int, static): bool $callback
      * @return bool
@@ -99,7 +99,7 @@ class Collection implements \ArrayAccess, \Countable, \IteratorAggregate
     /**
      * Returns true if at least one value in the collection passes the callback truthy test.
      * Callback arguments will be element, index, collection.
-     * Function short-circuits on first truthy return value
+     * Function short-circuits on first truthy return value.
      *
      * @param ?callable(T, int, static): bool $callback
      * @return bool
@@ -117,6 +117,106 @@ class Collection implements \ArrayAccess, \Countable, \IteratorAggregate
         }
 
         return false;
+    }
+
+    /**
+     * Returns the first element of the collection that matches the given callback.
+     * If no callback is given the first element in the collection is returned.
+     * Throws exception if collection is empty or the given callback was never satisfied.
+     *
+     * @param ?callable(T, int, static): bool $callback
+     * @return T
+     * @throws InvalidArgumentException
+     */
+    public function first(callable $callback = null)
+    {
+        if ($this->items === []) {
+            throw new InvalidArgumentException('No items in collection');
+        }
+
+        foreach ($this->items as $index => $item) {
+            if ($callback === null || $callback($item, $index, $this)) {
+                return $item;
+            }
+        }
+
+        throw new InvalidArgumentException('No item found in collection that satisfies first callback');
+    }
+
+    /**
+     * Returns the first element of the collection that matches the given callback.
+     * If no callback is given the first element in the collection is returned.
+     * If the collection is empty the given fallback value is returned instead.
+     *
+     * @template U of T|mixed
+     * @param ?callable(T, int, static): bool $callback
+     * @param U $fallbackValue
+     * @return U
+     * @throws InvalidArgumentException
+     */
+    public function firstOr(callable $callback = null, mixed $fallbackValue = null)
+    {
+        if ($this->items === []) {
+            return $fallbackValue;
+        }
+
+        foreach ($this->items as $index => $item) {
+            if ($callback === null || $callback($item, $index, $this)) {
+                return $item;
+            }
+        }
+
+        return $fallbackValue;
+    }
+
+    /**
+     * Returns the last element of the collection that matches the given callback.
+     * If no callback is given the last element in the collection is returned.
+     * Throws exception if collection is empty or the given callback was never satisfied.
+     *
+     * @param ?callable(T, int, static): bool $callback
+     * @return T
+     * @throws InvalidArgumentException
+     */
+    public function last(callable $callback = null)
+    {
+        if ($this->items === []) {
+            throw new InvalidArgumentException('No items in collection');
+        }
+
+        foreach (array_reverse($this->items) as $index => $item) {
+            if ($callback === null || $callback($item, $index, $this)) {
+                return $item;
+            }
+        }
+
+        throw new InvalidArgumentException('No item found in collection that satisfies last callback');
+    }
+
+    /**
+     * Returns the last element of the collection that matches the given callback.
+     * If no callback is given the last element in the collection is returned.
+     * If the collection is empty the given fallback value is returned instead.
+     *
+     * @template U of T|mixed
+     * @param ?callable(T, int, static): bool $callback
+     * @param U $fallbackValue
+     * @return U
+     * @throws InvalidArgumentException
+     */
+    public function lastOr(callable $callback = null, mixed $fallbackValue = null)
+    {
+        if ($this->items === []) {
+            return $fallbackValue;
+        }
+
+        foreach (array_reverse($this->items) as $index => $item) {
+            if ($callback === null || $callback($item, $index, $this)) {
+                return $item;
+            }
+        }
+
+        return $fallbackValue;
     }
 
     /**

--- a/src/Domain/Collection.php
+++ b/src/Domain/Collection.php
@@ -4,16 +4,28 @@ declare(strict_types=1);
 
 namespace GeekCell\Ddd\Domain;
 
+use ArrayAccess;
+use ArrayIterator;
 use Assert;
+use Countable;
 use InvalidArgumentException;
+use IteratorAggregate;
 use Traversable;
+use function array_filter;
+use function array_map;
+use function array_reduce;
+use function array_values;
+use function count;
+use function get_class;
+use function is_int;
+use function reset;
 
 /**
  * @template T of object
- * @implements \IteratorAggregate<T>
- * @implements \ArrayAccess<mixed, T>
+ * @implements IteratorAggregate<T>
+ * @implements ArrayAccess<mixed, T>
  */
-class Collection implements \ArrayAccess, \Countable, \IteratorAggregate
+class Collection implements ArrayAccess, Countable, IteratorAggregate
 {
     /**
      * @param T[] $items
@@ -249,7 +261,7 @@ class Collection implements \ArrayAccess, \Countable, \IteratorAggregate
     public function filter(callable $callback): static
     {
         return new static(
-            \array_values(\array_filter($this->items, $callback)),
+            array_values(array_filter($this->items, $callback)),
             $this->itemType,
         );
     }
@@ -267,15 +279,15 @@ class Collection implements \ArrayAccess, \Countable, \IteratorAggregate
      */
     public function map(callable $callback, bool $inferTypes = true): static
     {
-        $mapResult = \array_map($callback, $this->items);
-        $firstItem = \reset($mapResult);
+        $mapResult = array_map($callback, $this->items);
+        $firstItem = reset($mapResult);
 
         if ($firstItem === false || !is_object($firstItem)) {
             return new static($mapResult);
         }
 
         if ($inferTypes && $this->itemType !== null) {
-            return new static($mapResult, \get_class($firstItem));
+            return new static($mapResult, get_class($firstItem));
         }
 
         return new static($mapResult);
@@ -291,7 +303,7 @@ class Collection implements \ArrayAccess, \Countable, \IteratorAggregate
      */
     public function reduce(callable $callback, mixed $initial = null): mixed
     {
-        return \array_reduce($this->items, $callback, $initial);
+        return array_reduce($this->items, $callback, $initial);
     }
 
     /**
@@ -299,7 +311,7 @@ class Collection implements \ArrayAccess, \Countable, \IteratorAggregate
      */
     public function offsetExists(mixed $offset): bool
     {
-        if (!\is_int($offset)) {
+        if (!is_int($offset)) {
             return false;
         }
 
@@ -345,7 +357,7 @@ class Collection implements \ArrayAccess, \Countable, \IteratorAggregate
      */
     public function count(): int
     {
-        return \count($this->items);
+        return count($this->items);
     }
 
     /**
@@ -353,6 +365,6 @@ class Collection implements \ArrayAccess, \Countable, \IteratorAggregate
      */
     public function getIterator(): Traversable
     {
-        return new \ArrayIterator($this->items);
+        return new ArrayIterator($this->items);
     }
 }

--- a/src/Domain/Collection.php
+++ b/src/Domain/Collection.php
@@ -5,6 +5,8 @@ declare(strict_types=1);
 namespace GeekCell\Ddd\Domain;
 
 use Assert;
+use InvalidArgumentException;
+use Traversable;
 
 /**
  * @template T of object
@@ -27,10 +29,31 @@ class Collection implements \ArrayAccess, \Countable, \IteratorAggregate
     }
 
     /**
+     * Creates a collection from a given iterable of items.
+     * This function is useful when trying to create a collection from a generator or an iterator
+     *
+     * @param iterable<T> $items
+     * @param class-string<T>|null $itemType
+     * @return self<T>
+     */
+    public static function fromIterable(iterable $items, ?string $itemType = null): static
+    {
+        if (is_array($items)) {
+            return new static($items, $itemType);
+        }
+
+        if (!$items instanceof Traversable) {
+            $items = [...$items];
+        }
+
+        return new static(iterator_to_array($items), $itemType);
+    }
+
+    /**
      * Add one or more items to the collection. It **does not** modify the
      * current collection, but returns a new one.
      *
-     * @param mixed $item One or more items to add to the collection.
+     * @param T|iterable<T> $item One or more items to add to the collection.
      * @return static
      */
     public function add(mixed $item): static
@@ -158,7 +181,7 @@ class Collection implements \ArrayAccess, \Countable, \IteratorAggregate
     /**
      * @inheritDoc
      */
-    public function getIterator(): \Traversable
+    public function getIterator(): Traversable
     {
         return new \ArrayIterator($this->items);
     }

--- a/tests/Domain/CollectionTest.php
+++ b/tests/Domain/CollectionTest.php
@@ -320,4 +320,115 @@ class CollectionTest extends TestCase
         $collectionFromGenerator = Collection::fromIterable($generatorFn());
         $this->assertSame($items, iterator_to_array($collectionFromGenerator));
     }
+
+    public function testEvery(): void
+    {
+        $items = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10];
+        $collection = new Collection($items);
+
+        $this->assertFalse($collection->every(static fn ($item) => $item > 10));
+        $this->assertFalse($collection->every(static fn ($item) => $item > 5));
+        $this->assertTrue($collection->every(static fn ($item) => $item > 0));
+    }
+
+    public function testEveryWithoutArgumentDefaultsToTruthyCheck(): void
+    {
+        $this->assertTrue((new Collection([1, true]))->every());
+        $this->assertTrue((new Collection([1, true]))->every());
+        $this->assertFalse((new Collection([null, false]))->every());
+        $this->assertFalse((new Collection([false, null]))->every());
+        $this->assertFalse((new Collection([0, false]))->every());
+    }
+
+    public function testEveryReturnsTrueOnEmptyCollection(): void
+    {
+        $this->assertTrue((new Collection())->every(static fn ($item) => false));
+    }
+
+    public function testEveryShortCircuitsOnFirstFalsyValue(): void
+    {
+        $items = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10];
+        $collection = new Collection($items);
+
+        $collection->every(function ($item, $index, $c) use ($collection): bool {
+            // First item already returns false therefore the index should never be something other than 0
+            $this->assertSame(0, $index);
+            $this->assertSame($c, $collection);
+            return false;
+        });
+    }
+
+    public function testNone(): void
+    {
+        $items = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10];
+        $collection = new Collection($items);
+
+        $this->assertTrue($collection->none(static fn ($item) => $item > 10));
+        $this->assertFalse($collection->none(static fn ($item) => $item > 5));
+        $this->assertFalse($collection->none(static fn ($item) => $item > 0));
+    }
+
+    public function testNoneWithoutArgumentDefaultsToTruthyCheck(): void
+    {
+        $this->assertFalse((new Collection([1, true]))->none());
+        $this->assertFalse((new Collection([1, true]))->none());
+        $this->assertTrue((new Collection([null, false]))->none());
+        $this->assertTrue((new Collection([false, null]))->none());
+        $this->assertTrue((new Collection([0, false]))->none());
+    }
+
+    public function testNoneReturnsFalseOnEmptyCollection(): void
+    {
+        $this->assertTrue((new Collection())->none(static fn ($item) => true));
+    }
+
+    public function testNoneShortCircuitsOnFirstFalsyValue(): void
+    {
+        $items = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10];
+        $collection = new Collection($items);
+
+        $collection->none(function ($item, $index, $c) use ($collection): bool {
+            // First item already returns true therefore the index should never be something other than 0
+            $this->assertSame(0, $index);
+            $this->assertSame($c, $collection);
+            return true;
+        });
+    }
+
+    public function testSome(): void
+    {
+        $items = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10];
+        $collection = new Collection($items);
+
+        $this->assertFalse($collection->some(static fn ($item) => $item > 10));
+        $this->assertTrue($collection->some(static fn ($item) => $item > 5));
+        $this->assertTrue($collection->some(static fn ($item) => $item > 0));
+    }
+
+    public function testSomeWithoutArgumentDefaultsToTruthyCheck(): void
+    {
+        $this->assertTrue((new Collection([1, true]))->some());
+        $this->assertTrue((new Collection([1, true]))->some());
+        $this->assertFalse((new Collection([null, false]))->some());
+        $this->assertFalse((new Collection([false, null]))->some());
+        $this->assertFalse((new Collection([0, false]))->some());
+    }
+
+    public function testSomeReturnsFalseOnEmptyCollection(): void
+    {
+        $this->assertFalse((new Collection())->some(static fn ($item) => true));
+    }
+
+    public function testSomeShortCircuitsOnFirstFalsyValue(): void
+    {
+        $items = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10];
+        $collection = new Collection($items);
+
+        $collection->some(function ($item, $index, $c) use ($collection): bool {
+            // First item already returns true therefore the index should never be something other than 0
+            $this->assertSame(0, $index);
+            $this->assertSame($c, $collection);
+            return true;
+        });
+    }
 }

--- a/tests/Domain/CollectionTest.php
+++ b/tests/Domain/CollectionTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace GeekCell\Ddd\Tests\Domain;
 
+use ArrayIterator;
 use Assert;
 use GeekCell\Ddd\Domain\Collection;
 use PHPUnit\Framework\TestCase;
@@ -299,5 +300,24 @@ class CollectionTest extends TestCase
 
         // Then
         $this->assertEquals(60, $result);
+    }
+
+    public function testFromIterable(): void
+    {
+        $items = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10];
+        $collectionFromArray = Collection::fromIterable($items);
+        $this->assertSame($items, iterator_to_array($collectionFromArray));
+
+        $collectionFromIterator = Collection::fromIterable(new ArrayIterator($items));
+        $this->assertSame($items, iterator_to_array($collectionFromIterator));
+
+        $generatorFn = static function () use ($items) {
+            foreach ($items as $item) {
+                yield $item;
+            }
+        };
+
+        $collectionFromGenerator = Collection::fromIterable($generatorFn());
+        $this->assertSame($items, iterator_to_array($collectionFromGenerator));
     }
 }

--- a/tests/Domain/CollectionTest.php
+++ b/tests/Domain/CollectionTest.php
@@ -526,4 +526,16 @@ class CollectionTest extends TestCase
         $collection = new Collection($items);
         $this->assertSame(-1, $collection->lastOr(static fn ($item) => $item > 10, -1));
     }
+
+    public function testIsEmpty(): void
+    {
+        $this->assertFalse((new Collection([1]))->isEmpty());
+        $this->assertTrue((new Collection([]))->isEmpty());
+    }
+
+    public function testHasItems(): void
+    {
+        $this->assertFalse((new Collection([]))->hasItems());
+        $this->assertTrue((new Collection([1]))->hasItems());
+    }
 }

--- a/tests/Domain/CollectionTest.php
+++ b/tests/Domain/CollectionTest.php
@@ -7,6 +7,7 @@ namespace GeekCell\Ddd\Tests\Domain;
 use ArrayIterator;
 use Assert;
 use GeekCell\Ddd\Domain\Collection;
+use InvalidArgumentException;
 use PHPUnit\Framework\TestCase;
 
 /**
@@ -430,5 +431,99 @@ class CollectionTest extends TestCase
             $this->assertSame($c, $collection);
             return true;
         });
+    }
+
+    public function testFirst(): void
+    {
+        $items = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10];
+        $collection = new Collection($items);
+
+        $this->assertSame(1, $collection->first());
+    }
+
+    public function testFirstThrowsExceptionOnEmptyCollection(): void
+    {
+        $collection = new Collection([]);
+
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('No items in collection');
+        $collection->first();
+    }
+
+    public function testFirstThrowsExceptionIfCallbackIsNeverSatisfied(): void
+    {
+        $items = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10];
+        $collection = new Collection($items);
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('No item found in collection that satisfies first callback');
+        $collection->first(static fn () => false);
+    }
+
+    public function testFirstOrReturnsFirstValueInCollectionIfNoCallbackIsGiven(): void
+    {
+        $items = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10];
+        $collection = new Collection($items);
+        $this->assertSame(1, $collection->firstOr());
+    }
+
+    public function testFirstOrReturnsFirstValueThatSatisfiesCallback(): void
+    {
+        $items = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10];
+        $collection = new Collection($items);
+        $this->assertSame(6, $collection->firstOr(static fn ($item) => $item > 5));
+    }
+
+    public function testFirstOrReturnsFallbackValueIfCallbackIsNeverSatisfied(): void
+    {
+        $items = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10];
+        $collection = new Collection($items);
+        $this->assertSame(-1, $collection->firstOr(static fn ($item) => $item > 10, -1));
+    }
+
+    public function testLast(): void
+    {
+        $items = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10];
+        $collection = new Collection($items);
+
+        $this->assertSame(10, $collection->last());
+    }
+
+    public function testLastThrowsExceptionOnEmptyCollection(): void
+    {
+        $collection = new Collection([]);
+
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('No items in collection');
+        $collection->last();
+    }
+
+    public function testLastThrowsExceptionIfCallbackIsNeverSatisfied(): void
+    {
+        $items = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10];
+        $collection = new Collection($items);
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('No item found in collection that satisfies last callback');
+        $collection->last(static fn () => false);
+    }
+
+    public function testLastOrReturnsLastValueInCollectionIfNoCallbackIsGiven(): void
+    {
+        $items = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10];
+        $collection = new Collection($items);
+        $this->assertSame(10, $collection->lastOr());
+    }
+
+    public function testLastOrReturnsLastValueThatSatisfiesCallback(): void
+    {
+        $items = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10];
+        $collection = new Collection($items);
+        $this->assertSame(10, $collection->lastOr(static fn ($item) => $item > 5));
+    }
+
+    public function testLastOrReturnsFallbackValueIfCallbackIsNeverSatisfied(): void
+    {
+        $items = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10];
+        $collection = new Collection($items);
+        $this->assertSame(-1, $collection->lastOr(static fn ($item) => $item > 10, -1));
     }
 }


### PR DESCRIPTION
This PR introduces a couple of useful functions to the Collection class.

The introduced functions are:

* `fromIterable` - enables users of the collection to construction the collection from an iterable value like iterators, generators, etc.
* `every` - Returns true if given callback returns truthy values for all items
* `none` - Returns true if given callback returns falsy values for all items
* `some` - Returns true if given callback returns truthy values on some items
* `first` - Get the first element of the collection that matches a callback, if given. Throws exception if collection is empty or predicate is never satisfied
* `firstOr` - Same as first but returns $fallbackValue if collection is empty or predicate is never satisfied
* `last` - Get the last element of the collection that matches a callback, if given. Throws exception if collection is empty or predicate is never satisfied
* `lastOr` - Same as last but returns $fallbackValue if collection is empty or predicate is never satisfied
* `isEmpty` - Returns whether the collection is empty
* `hasItems` - Returns whether the collection has items