### PR TITLE
fix: Add T as a possible return type for lastOr and firstOr

### DIFF
--- a/src/Domain/Collection.php
+++ b/src/Domain/Collection.php
@@ -163,7 +163,7 @@ class Collection implements ArrayAccess, Countable, IteratorAggregate
      * @template U of T|mixed
      * @param ?callable(T, int, static): bool $callback
      * @param U $fallbackValue
-     * @return U
+     * @return U|T
      * @throws InvalidArgumentException
      */
     public function firstOr(callable $callback = null, mixed $fallbackValue = null)
@@ -213,7 +213,7 @@ class Collection implements ArrayAccess, Countable, IteratorAggregate
      * @template U of T|mixed
      * @param ?callable(T, int, static): bool $callback
      * @param U $fallbackValue
-     * @return U
+     * @return U|T
      * @throws InvalidArgumentException
      */
     public function lastOr(callable $callback = null, mixed $fallbackValue = null)


### PR DESCRIPTION
PHPStan will complain about a value always returning `null` from `firstOr` /  `lastOr` if no sensible default is given.

This PR adapts the PHPDoc return signature to allow both `T` and  `U` to be returned from the `firstOr` and `lastOr` functions. No changes for tests are required