### PR TITLE
feat: add find and findLast functions

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -38,12 +38,4 @@ jobs:
 
             # Run tests
             - name: Run Unit Tests
-              run: |
-                vendor/bin/phpunit --coverage-text --coverage-clover reports/coverage.xml
-
-            # SonarCloud
-            - name: SonarCloud Scan
-              uses: SonarSource/sonarcloud-github-action@master
-              env:
-                GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-                SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+              run: vendor/bin/phpunit

--- a/src/Domain/Collection.php
+++ b/src/Domain/Collection.php
@@ -23,13 +23,14 @@ use function reset;
 /**
  * @template T of object
  * @implements IteratorAggregate<T>
- * @implements ArrayAccess<mixed, T>
+ * @implements ArrayAccess<array-key, T>
  */
 class Collection implements ArrayAccess, Countable, IteratorAggregate
 {
     /**
      * @param T[] $items
      * @param class-string<T>|null $itemType
+     * @throws Assert\AssertionFailedException
      */
     final public function __construct(
         private readonly array $items = [],
@@ -129,6 +130,42 @@ class Collection implements ArrayAccess, Countable, IteratorAggregate
         }
 
         return false;
+    }
+
+    /**
+     * Returns the first element of the collection that matches the given callback or null if the collection is empty
+     * or the callback never returned true for any item
+     *
+     * @param callable(T, int, static): bool $callback
+     * @return ?T
+     */
+    public function find(callable $callback)
+    {
+        foreach ($this->items as $index => $item) {
+            if ($callback($item, $index, $this)) {
+                return $item;
+            }
+        }
+
+        return null;
+    }
+
+    /**
+     * Returns the last element of the collection that matches the given callback or null if the collection is empty
+     * or the callback never returned true for any item
+     *
+     * @param callable(T, int, static): bool $callback
+     * @return ?T
+     */
+    public function findLast(callable $callback)
+    {
+        foreach (array_reverse($this->items) as $index => $item) {
+            if ($callback($item, $index, $this)) {
+                return $item;
+            }
+        }
+
+        return null;
     }
 
     /**

--- a/tests/Domain/CollectionTest.php
+++ b/tests/Domain/CollectionTest.php
@@ -433,6 +433,52 @@ class CollectionTest extends TestCase
         });
     }
 
+    public function testFind(): void
+    {
+        $items = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10];
+        $collection = new Collection($items);
+
+        $this->assertSame(3, $collection->find(static fn ($item) => $item > 2));
+    }
+
+    public function testFindReturnsNullIfCallbackNeverReturnsTrue(): void
+    {
+        $items = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10];
+        $collection = new Collection($items);
+
+        $this->assertSame(null, $collection->find(static fn () => false));
+    }
+
+    public function testFindReturnsNullOnEmptyCollection(): void
+    {
+        $collection = new Collection([]);
+
+        $this->assertSame(null, $collection->find(static fn () => true));
+    }
+
+    public function testFindLast(): void
+    {
+        $items = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10];
+        $collection = new Collection($items);
+
+        $this->assertSame(10, $collection->findLast(static fn ($item) => $item > 2));
+    }
+
+    public function testFindLastReturnsNullIfCallbackNeverReturnsTrue(): void
+    {
+        $items = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10];
+        $collection = new Collection($items);
+
+        $this->assertSame(null, $collection->findLast(static fn () => false));
+    }
+
+    public function testFindLastReturnsNullOnEmptyCollection(): void
+    {
+        $collection = new Collection([]);
+
+        $this->assertSame(null, $collection->find(static fn () => true));
+    }
+
     public function testFirst(): void
     {
         $items = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10];
@@ -477,7 +523,7 @@ class CollectionTest extends TestCase
     {
         $items = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10];
         $collection = new Collection($items);
-        $this->assertSame(-1, $collection->firstOr(static fn ($item) => $item > 10, -1));
+        $this->assertSame(-1, $collection->firstOr(static fn () => false, -1));
     }
 
     public function testLast(): void
@@ -524,7 +570,7 @@ class CollectionTest extends TestCase
     {
         $items = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10];
         $collection = new Collection($items);
-        $this->assertSame(-1, $collection->lastOr(static fn ($item) => $item > 10, -1));
+        $this->assertSame(-1, $collection->lastOr(static fn () => false, -1));
     }
 
     public function testIsEmpty(): void


### PR DESCRIPTION
A user of this library might be looking for a function to find the first (or last) element that matches a predicate while not wanting to provide a default. If that is the case a user currently has to call `$collection->firstOr($callback)` or `$collection->lastOr($callback)`. Instead we should provide a `find` and `findLast` function that does exactly that.