### PR TITLE
Feat: Add toArray and toList functions to Collection

### DIFF
--- a/src/Domain/Collection.php
+++ b/src/Domain/Collection.php
@@ -28,7 +28,7 @@ use function reset;
 class Collection implements ArrayAccess, Countable, IteratorAggregate
 {
     /**
-     * @param T[] $items
+     * @param array<array-key, T> $items
      * @param class-string<T>|null $itemType
      * @throws Assert\AssertionFailedException
      */
@@ -61,6 +61,27 @@ class Collection implements ArrayAccess, Countable, IteratorAggregate
         }
 
         return new static(iterator_to_array($items), $itemType);
+    }
+
+    /**
+     * Returns the collection as an array.
+     * The returned array is either a key-value array with values of type T or a list of T
+     *
+     * @return array<array-key, T>|list<T>
+     */
+    public function toArray(): array
+    {
+        return $this->items;
+    }
+
+    /**
+     * Returns the collection as a list of T
+     *
+     * @return list<T>
+     */
+    public function toList(): array
+    {
+        return array_values($this->items);
     }
 
     /**

--- a/src/Domain/Collection.php
+++ b/src/Domain/Collection.php
@@ -11,6 +11,7 @@ use Countable;
 use InvalidArgumentException;
 use IteratorAggregate;
 use Traversable;
+
 use function array_filter;
 use function array_map;
 use function array_reduce;

--- a/tests/Domain/CollectionTest.php
+++ b/tests/Domain/CollectionTest.php
@@ -156,7 +156,7 @@ class CollectionTest extends TestCase
     public function testFilter(): void
     {
         // Given
-        $items = [1, 2, 3,4, 5, 6, 7, 8, 9, 10];
+        $items = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10];
         $collection = new Collection($items);
 
         // When
@@ -583,5 +583,33 @@ class CollectionTest extends TestCase
     {
         $this->assertFalse((new Collection([]))->hasItems());
         $this->assertTrue((new Collection([1]))->hasItems());
+    }
+
+    public function testToArray(): void
+    {
+        $this->assertSame([], (new Collection([]))->toArray());
+
+        $list = [1, 2, 3];
+        $this->assertSame($list, (new Collection($list))->toArray());
+
+        $keyValue = ['foo' => 1, 'bar' => 2, 'baz' => 3];
+        $this->assertSame($keyValue, (new Collection($keyValue))->toArray());
+
+        $numberIndexed = [1 => 1, 2 => 2, 3 => 3, 0 => 0];
+        $this->assertSame($numberIndexed, (new Collection($numberIndexed))->toArray());
+    }
+
+    public function testToList(): void
+    {
+        $this->assertSame([], (new Collection([]))->toList());
+
+        $list = [1, 2, 3];
+        $this->assertSame($list, (new Collection($list))->toList());
+
+        $keyValue = ['foo' => 1, 'bar' => 2, 'baz' => 3];
+        $this->assertSame([1, 2, 3], (new Collection($keyValue))->toList());
+
+        $numberIndexed = [1 => 1, 2 => 2, 3 => 3, 0 => 0];
+        $this->assertSame([1, 2, 3, 0], (new Collection($numberIndexed))->toList());
     }
 }


### PR DESCRIPTION
As a user of the the library I sometimes find myself wanting to use the collection as an array/list to, for example, sort it.

This usually will look like this:
```php
$collection = new Collection([1,2,3]);
$array = iterator_to_array($collection);
$sorted = usort($array, static fn (int $valueA, int $valueB) => $valueA <=> $valueB);
```

Or in a case where I want to use the collection as a list of items to, for example, expose it in a symfony controller and want to make sure that it's returned as a list instead of a potential associative array:
```php
$collection = new Collection([1,2,3]);
$list = array_values(iterator_to_array($collection));
return $this->json($list);
```

Which, in both cases, the library could do internally which is why this PR introduces these functions